### PR TITLE
Add folder monitoring and manual processing features

### DIFF
--- a/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.js
+++ b/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.js
@@ -10,12 +10,12 @@ frappe.ui.form.on('Doc2Sys Settings', {
                 frappe.call({
                     method: 'doc2sys.doc2sys.doctype.doc2sys_settings.doc2sys_settings.run_folder_monitor',
                     freeze: true,
-                    freeze_message: __('Processing files from source folder...'),
+                    freeze_message: __('Processing files from monitor folder...'),
                     callback: function(r) {
                         if (r.message && r.message.success) {
                             frappe.msgprint({
                                 title: __('Folder Processing Complete'),
-                                message: __('Files from the source folder have been processed.'),
+                                message: __('Files from the monitor folder have been processed.'),
                                 indicator: 'green'
                             });
                         } else {

--- a/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.js
+++ b/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.js
@@ -3,33 +3,31 @@
 
 frappe.ui.form.on('Doc2Sys Settings', {
     refresh: function(frm) {
-
-        // Add test Ollama connection button
-        if (frm.doc.use_llm && frm.doc.llm_provider === "Ollama") {
-            frm.add_custom_button(__('Test Ollama Connection'), function() {
+        
+        // Add manual folder processing button
+        if (frm.doc.monitoring_enabled) {
+            frm.add_custom_button(__('Process Folder Now'), function() {
                 frappe.call({
-                    method: 'doc2sys.doc2sys.doctype.doc2sys_settings.doc2sys_settings.test_ollama_connection',
+                    method: 'doc2sys.doc2sys.doctype.doc2sys_settings.doc2sys_settings.run_folder_monitor',
                     freeze: true,
-                    freeze_message: __('Testing connection to Ollama server...'),
+                    freeze_message: __('Processing files from source folder...'),
                     callback: function(r) {
                         if (r.message && r.message.success) {
                             frappe.msgprint({
-                                title: __('Ollama Connection Successful'),
-                                message: r.message.message + "<br><br>" + 
-                                         __('Available models: ') + r.message.available_models.join(', ') + "<br><br>" +
-                                         __('Response sample: ') + `<pre>${r.message.response_sample}</pre>`,
+                                title: __('Folder Processing Complete'),
+                                message: __('Files from the source folder have been processed.'),
                                 indicator: 'green'
                             });
                         } else {
                             frappe.msgprint({
-                                title: __('Ollama Connection Failed'),
+                                title: __('Folder Processing Failed'),
                                 message: r.message ? r.message.message : __('Unknown error'),
                                 indicator: 'red'
                             });
                         }
                     }
                 });
-            }, __('LLM'));
+            }, __('Folder Monitor'));
         }
     }
 });

--- a/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.json
+++ b/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.json
@@ -15,8 +15,7 @@
   "supported_file_types",
   "folder_monitoring_section",
   "monitoring_enabled",
-  "source_folder",
-  "destination_folder",
+  "monitor_folder",
   "monitor_interval",
   "ocr_section",
   "ocr_enabled",
@@ -88,21 +87,14 @@
    "fieldtype": "Check",
    "label": "Enable Folder Monitoring",
    "default": "0",
-   "description": "Enable automatic processing of files from the source folder"
+   "description": "Enable automatic processing of files from the monitored folder"
   },
   {
-   "fieldname": "source_folder",
+   "fieldname": "monitor_folder",
    "fieldtype": "Data",
-   "label": "Source Folder Path",
+   "label": "Folder to Monitor",
    "depends_on": "eval:doc.monitoring_enabled==1",
    "description": "Directory where system will look for files to process"
-  },
-  {
-   "fieldname": "destination_folder",
-   "fieldtype": "Data",
-   "label": "Destination Folder Path",
-   "depends_on": "eval:doc.monitoring_enabled==1",
-   "description": "Directory where processed files will be moved"
   },
   {
    "fieldname": "monitor_interval",
@@ -110,7 +102,7 @@
    "label": "Monitor Interval (minutes)",
    "depends_on": "eval:doc.monitoring_enabled==1",
    "default": "15",
-   "description": "How often to check the source folder for new files"
+   "description": "How often to check the monitored folder for new files"
   },
   {
    "fieldname": "ocr_section",

--- a/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.json
+++ b/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.json
@@ -13,6 +13,11 @@
   "max_file_size_mb",
   "file_types_section",
   "supported_file_types",
+  "folder_monitoring_section",
+  "monitoring_enabled",
+  "source_folder",
+  "destination_folder",
+  "monitor_interval",
   "ocr_section",
   "ocr_enabled",
   "ocr_languages",
@@ -72,6 +77,40 @@
    "fieldtype": "Table",
    "label": "Supported File Types",
    "options": "Doc2Sys File Type"
+  },
+  {
+   "fieldname": "folder_monitoring_section",
+   "fieldtype": "Section Break",
+   "label": "Folder Monitoring"
+  },
+  {
+   "fieldname": "monitoring_enabled",
+   "fieldtype": "Check",
+   "label": "Enable Folder Monitoring",
+   "default": "0",
+   "description": "Enable automatic processing of files from the source folder"
+  },
+  {
+   "fieldname": "source_folder",
+   "fieldtype": "Data",
+   "label": "Source Folder Path",
+   "depends_on": "eval:doc.monitoring_enabled==1",
+   "description": "Directory where system will look for files to process"
+  },
+  {
+   "fieldname": "destination_folder",
+   "fieldtype": "Data",
+   "label": "Destination Folder Path",
+   "depends_on": "eval:doc.monitoring_enabled==1",
+   "description": "Directory where processed files will be moved"
+  },
+  {
+   "fieldname": "monitor_interval",
+   "fieldtype": "Int",
+   "label": "Monitor Interval (minutes)",
+   "depends_on": "eval:doc.monitoring_enabled==1",
+   "default": "15",
+   "description": "How often to check the source folder for new files"
   },
   {
    "fieldname": "ocr_section",

--- a/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.py
+++ b/doc2sys/doc2sys/doctype/doc2sys_settings/doc2sys_settings.py
@@ -9,6 +9,7 @@ class Doc2SysSettings(Document):
         """Validate settings"""
         if self.max_file_size_mb <= 0:
             frappe.throw("Maximum file size must be greater than 0")
+        self.update_scheduler()
             
     def get_supported_file_extensions(self):
         """Return list of supported file extensions"""
@@ -18,63 +19,35 @@ class Doc2SysSettings(Document):
         """Return max file size in bytes"""
         return self.max_file_size_mb * 1024 * 1024
 
-@frappe.whitelist()
-def test_ollama_connection():
-    """Test connection to Ollama server"""
-    import requests
-    
-    try:
-        endpoint = frappe.db.get_single_value("Doc2Sys Settings", "ollama_endpoint") or "http://localhost:11434"
-        model = frappe.db.get_single_value("Doc2Sys Settings", "ollama_model") or "llama3"
-        
-        # First check models endpoint to see if server is up
-        response = requests.get(f"{endpoint}/api/tags")
-        
-        if response.status_code != 200:
-            return {
-                "success": False,
-                "message": f"Failed to connect to Ollama server: {response.text}"
-            }
+    def update_scheduler(self):
+        """Update the scheduler interval based on settings"""
+        if not self.monitor_interval or not self.monitoring_enabled:
+            return
             
-        # Get list of models
-        models = response.json().get("models", [])
-        model_names = [m["name"] for m in models]
-        
-        # Check if specified model is available
-        if model not in model_names:
-            return {
-                "success": False,
-                "message": f"Model '{model}' not found. Available models: {', '.join(model_names)}"
-            }
-            
-        # Test simple completion
-        chat_response = requests.post(
-            f"{endpoint}/api/chat",
-            json={
-                "model": model,
-                "messages": [
-                    {"role": "user", "content": "Hello, can you respond with a simple JSON? {'test': 'successful'}"}
-                ],
-                "stream": False
-            }
+        # Get the current job
+        job = frappe.get_all(
+            "Scheduled Job Type",
+            filters={"method": "doc2sys.doc2sys.tasks.folder_monitor.monitor_folders"},
+            fields=["name", "cron_format"]
         )
         
-        if chat_response.status_code != 200:
-            return {
-                "success": False,
-                "message": f"Failed to get response from model: {chat_response.text}"
-            }
+        if not job:
+            return
             
-        return {
-            "success": True,
-            "message": "Successfully connected to Ollama server",
-            "available_models": model_names,
-            "response_sample": chat_response.json().get("message", {}).get("content", "")
-        }
-            
-    except Exception as e:
-        frappe.log_error(f"Error testing Ollama connection: {str(e)}")
-        return {
-            "success": False,
-            "message": f"Error connecting to Ollama: {str(e)}"
-        }
+        # Create the new cron format based on settings
+        new_cron = f"*/{self.monitor_interval} * * * *"
+        
+        # Update the job if needed
+        if job[0].cron_format != new_cron:
+            frappe.db.set_value("Scheduled Job Type", job[0].name, "cron_format", new_cron)
+            frappe.db.commit()
+
+@frappe.whitelist()
+def run_folder_monitor():
+    """Manually run the folder monitor process"""
+    from doc2sys.doc2sys.tasks.folder_monitor import monitor_folders
+    monitor_folders()
+    return {
+        "success": True,
+        "message": "Folder monitoring process completed"
+    }

--- a/doc2sys/doc2sys/tasks/folder_monitor.py
+++ b/doc2sys/doc2sys/tasks/folder_monitor.py
@@ -1,0 +1,132 @@
+import os
+import shutil
+import frappe
+from frappe import _
+from frappe.utils import get_site_path, get_site_base_path
+
+def get_absolute_path(path):
+    """
+    Convert a path to absolute path considering site directory structure.
+    Checks if the path is:
+    1. Already absolute
+    2. Relative to site directory
+    3. Relative to sites directory
+    """
+    if os.path.isabs(path) and os.path.exists(path):
+        return path
+        
+    # Try relative to site directory
+    site_path = os.path.join(get_site_path(), path.lstrip('/'))
+    if os.path.exists(site_path):
+        return site_path
+        
+    # Try relative to sites base directory
+    base_path = os.path.join(get_site_base_path(), path.lstrip('/'))
+    if os.path.exists(base_path):
+        return base_path
+        
+    # Try relative to private directory
+    private_path = os.path.join(get_site_path('private'), path.lstrip('/'))
+    if os.path.exists(private_path):
+        return private_path
+        
+    # Return the original path if all else fails
+    return path
+
+def monitor_folders():
+    """
+    Check source folder for files, process them, and move to destination folder.
+    This function will be called by the scheduler at the configured interval.
+    """
+    settings = frappe.get_single("Doc2Sys Settings")
+    
+    if not settings.monitoring_enabled:
+        return
+        
+    # Get absolute paths for source and destination folders
+    source_path = get_absolute_path(settings.source_folder)
+    dest_path = get_absolute_path(settings.destination_folder)
+    
+    # Log the resolved paths for debugging
+    frappe.logger().info(f"Source path: {settings.source_folder} resolved to {source_path}")
+    frappe.logger().info(f"Destination path: {settings.destination_folder} resolved to {dest_path}")
+    
+    if not source_path or not os.path.isdir(source_path):
+        frappe.log_error(_("Source folder does not exist or is not configured: {0} (resolved to {1})").format(
+            settings.source_folder, source_path), 
+            _("Doc2Sys Folder Monitor"))
+        return
+        
+    if not dest_path or not os.path.isdir(dest_path):
+        frappe.log_error(_("Destination folder does not exist or is not configured: {0} (resolved to {1})").format(
+            settings.destination_folder, dest_path),
+            _("Doc2Sys Folder Monitor"))
+        return
+    
+    # Get list of files in source folder
+    files = [f for f in os.listdir(source_path) 
+             if os.path.isfile(os.path.join(source_path, f))]
+    
+    if not files:
+        return  # No files to process
+    
+    for file_name in files:
+        file_path = os.path.join(source_path, file_name)
+
+        try:
+            # Upload file to Frappe file system and create Doc2SysItem
+            file_url = upload_file_to_frappe(file_path, file_name)
+            
+            if not file_url:
+                frappe.log_error(_("Failed to upload file: {0}").format(file_path),
+                                _("Doc2Sys Folder Monitor"))
+                continue
+            
+            # Create Doc2SysItem instance with the file URL
+            doc2sys_item = frappe.get_doc({
+                "doctype": "Doc2Sys Item",
+                "title": file_name,
+                "single_file": file_url,
+                "file_path": file_path,
+            })
+            
+            # Save document (which triggers file processing through validate method)
+            doc2sys_item.insert()
+            
+            # Move file to destination folder
+            destination_path = os.path.join(dest_path, file_name)
+            shutil.move(file_path, destination_path)
+            
+            # Update doc2sys_item with the new file location
+            frappe.db.set_value("Doc2Sys Item", doc2sys_item.name, "file_path", destination_path)
+            
+            frappe.db.commit()
+            frappe.log(_("Successfully processed and moved file: {0}").format(file_name))
+            
+        except Exception as e:
+            frappe.log_error(_("Error processing file {0}: {1}").format(file_name, str(e)), 
+                            _("Doc2Sys Folder Monitor"))
+
+def upload_file_to_frappe(file_path, file_name):
+    """Upload file to Frappe file system and return file URL"""
+    try:
+        with open(file_path, 'rb') as f:
+            file_content = f.read()
+            
+        # Upload the file to Frappe's file system
+        file_doc = frappe.get_doc({
+            "doctype": "File",
+            "file_name": file_name,
+            "is_private": 1,
+            "folder": "Home/Attachments",
+            "attached_to_doctype": "Doc2Sys Item",
+            "attached_to_name": "New Doc2Sys Item",  # Temporary value
+            "content": file_content
+        })
+        
+        file_doc.insert()
+        return file_doc.file_url
+        
+    except Exception as e:
+        frappe.log_error(f"Error uploading file: {str(e)}")
+        return None

--- a/doc2sys/hooks.py
+++ b/doc2sys/hooks.py
@@ -166,6 +166,17 @@ after_install = "doc2sys.setup.install.after_install"
 # 	],
 # }
 
+# Scheduler
+# ---------------
+scheduler_events = {
+    "cron": {
+        # Monitor folders based on configured interval
+        "*/15 * * * *": [
+            "doc2sys.doc2sys.tasks.folder_monitor.monitor_folders"
+        ]
+    }
+}
+
 # Testing
 # -------
 


### PR DESCRIPTION
Introduce settings for folder monitoring, allowing users to enable monitoring of a single folder and process files manually. Update messages to clarify processing actions.