### PR TITLE
Add cost field and update cost calculation in Azure response caching

### DIFF
--- a/doc2sys/doc2sys/doctype/doc2sys_item/doc2sys_item.json
+++ b/doc2sys/doc2sys/doctype/doc2sys_item/doc2sys_item.json
@@ -13,6 +13,7 @@
   "single_file",
   "document_type",
   "classification_confidence",
+  "cost",
   "extracted_data_tab",
   "extracted_text",
   "column_break_ibav",
@@ -119,6 +120,14 @@
    "fieldname": "integration_status_section",
    "fieldtype": "Section Break",
    "label": "Integration Status"
+  },
+  {
+   "fieldname": "cost",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Cost (\u20ac)",
+   "non_negative": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -128,7 +137,7 @@
    "link_fieldname": "document"
   }
  ],
- "modified": "2025-03-25 17:41:02.184093",
+ "modified": "2025-03-26 09:56:44.429993",
  "modified_by": "Administrator",
  "module": "Doc2Sys",
  "name": "Doc2Sys Item",

--- a/doc2sys/doc2sys/doctype/doc2sys_user_settings/doc2sys_user_settings.json
+++ b/doc2sys/doc2sys/doctype/doc2sys_user_settings/doc2sys_user_settings.json
@@ -21,7 +21,7 @@
   "azure_endpoint",
   "azure_key",
   "azure_model",
-  "cost_invoice",
+  "cost_prebuilt_invoice_per_page",
   "external_integrations_tab",
   "integrations_section",
   "user_integrations"
@@ -144,15 +144,15 @@
    "non_negative": 1
   },
   {
-   "fieldname": "cost_invoice",
+   "fieldname": "cost_prebuilt_invoice_per_page",
    "fieldtype": "Currency",
-   "label": "Cost per 1,000 pages",
+   "label": "Cost (\u20ac) per 1,000 pages",
    "non_negative": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-26 09:02:08.646675",
+ "modified": "2025-03-26 09:52:42.334843",
  "modified_by": "Administrator",
  "module": "Doc2Sys",
  "name": "Doc2Sys User Settings",

--- a/doc2sys/engine/llm_processor.py
+++ b/doc2sys/engine/llm_processor.py
@@ -138,8 +138,7 @@ class AzureDocumentIntelligenceProcessor:
             ) or ""
             
             # Cache token pricing (per million tokens)
-            self.input_price_per_million = float(user_settings.input_token_price or 0.0)
-            self.output_price_per_million = float(user_settings.output_token_price or 0.0)
+            self.cost_prebuilt_invoice_per_page = float(user_settings.cost_prebuilt_invoice_per_page or 0.0)
             
             # Initialize Azure client
             try:
@@ -231,6 +230,9 @@ class AzureDocumentIntelligenceProcessor:
             # Process the result to extract structured data
             extracted_data = self._process_azure_extraction_results(result_dict)
             extracted_data = frappe.as_json(extracted_data, 1, None, False)
+
+            # Get the number of pages in result_dict
+            cost = len(result_dict.get("pages", [])) * self.cost_prebuilt_invoice_per_page / 1000
             
             # Save the raw response to doc2sys_item for future use if available
             if self.doc2sys_item:
@@ -244,6 +246,7 @@ class AzureDocumentIntelligenceProcessor:
                     doc2sys_item_doc.db_set('extracted_data', extracted_data, update_modified=False)
                     doc2sys_item_doc.db_set('azure_raw_response', serialized_result, update_modified=False)
                     doc2sys_item_doc.db_set('extracted_text', extracted_text, update_modified=False)
+                    doc2sys_item_doc.db_set('cost', cost, update_modified=False)
                 except Exception as e:
                     logger.warning(f"Failed to cache Azure response: {str(e)}")
             

--- a/doc2sys/engine/llm_processor.py
+++ b/doc2sys/engine/llm_processor.py
@@ -189,7 +189,7 @@ class AzureDocumentIntelligenceProcessor:
                         
                         # Deserialize the stored response
                         result_dict = json.loads(doc2sys_item_doc.azure_raw_response)
-                        
+
                         # Process the cached result to extract structured data
                         extracted_data = self._process_azure_extraction_results(result_dict)
                         extracted_data = frappe.as_json(extracted_data, 1, None, False)
@@ -198,6 +198,7 @@ class AzureDocumentIntelligenceProcessor:
                         return extracted_data
                 except Exception as e:
                     logger.warning(f"Failed to use cached Azure response: {str(e)}, proceeding with API call")
+                    return {}
             
             # Azure requires a file to process, so check if file path is provided
             if not file_path:
@@ -233,6 +234,8 @@ class AzureDocumentIntelligenceProcessor:
 
             # Get the number of pages in result_dict
             cost = len(result_dict.get("pages", [])) * self.cost_prebuilt_invoice_per_page / 1000
+            doc = result_dict.get("documents")[0]
+            confidence = doc.get("confidence")
             
             # Save the raw response to doc2sys_item for future use if available
             if self.doc2sys_item:
@@ -247,6 +250,7 @@ class AzureDocumentIntelligenceProcessor:
                     doc2sys_item_doc.db_set('azure_raw_response', serialized_result, update_modified=False)
                     doc2sys_item_doc.db_set('extracted_text', extracted_text, update_modified=False)
                     doc2sys_item_doc.db_set('cost', cost, update_modified=False)
+                    doc2sys_item_doc.db_set('classification_confidence', confidence, update_modified=False)
                 except Exception as e:
                     logger.warning(f"Failed to cache Azure response: {str(e)}")
             


### PR DESCRIPTION
Introduce a cost field to the doc2sys_item and modify user settings to reflect the cost per prebuilt invoice page. Update the Azure response caching to include classification confidence and adjust cost calculations accordingly.